### PR TITLE
Fix syndicate-read.cpp, length bug (resolves issue #3)

### DIFF
--- a/ug-tools/syndicate-read.cpp
+++ b/ug-tools/syndicate-read.cpp
@@ -112,7 +112,7 @@ int main( int argc, char** argv ) {
       nr = 0;
       num_read = 0;
       while( num_read < len ) {
-          nr = UG_read( ug, buf, BUF_LEN, fh );
+          nr = UG_read( ug, buf, std::min(len,(uint64_t)BUF_LEN), fh );
           if( nr < 0 ) {
     
              fprintf(stderr, "%s: read: %s\n", path, strerror(-nr));


### PR DESCRIPTION
Solution
--------

I assume the desire for the read test is to _read_ the data within the ranges specified, and this test is not about reading more than the specified data then providing stdout of the range specified (otherwise, I'd just change the fwrite on line 140).  This being the case, the solution requires a simple change at around line 114 as follows:

```
while( num_read < len ) {
    nr = UG_read( ug, buf, std::min(len,(uint64_t)BUF_LEN), fh );
```
After re-testing, the test comparisons now pass!