### PR TITLE
Fix length bug part II, resolves issue #3

### DIFF
--- a/ug-tools/syndicate-read.cpp
+++ b/ug-tools/syndicate-read.cpp
@@ -112,7 +112,7 @@ int main( int argc, char** argv ) {
       nr = 0;
       num_read = 0;
       while( num_read < len ) {
-          nr = UG_read( ug, buf, std::min(len,(uint64_t)BUF_LEN), fh );
+          nr = UG_read( ug, buf, std::min(len - num_read, (uint64_t)BUF_LEN), fh );
           if( nr < 0 ) {
     
              fprintf(stderr, "%s: read: %s\n", path, strerror(-nr));


### PR DESCRIPTION
Revised Solution
----------------
Illyoung pointed out that the proper solution should be:

```
while( num_read < len ) {
    nr = UG_read( ug, buf, std::min(len - num_read,(uint64_t)BUF_LEN), fh );
```

This accounts for reading ranges that exceed the buffer but remain less than the size of the file.

####Modified Test Case
Test 013\_ag\_read was modified to include "large file size" (2MB) tests, some of the reads exceed the buffer size, thus exercising the change Illyoung recommended.  Interestingly this test is also good for verifying the cache capabilities, since the duplicate reads are much faster.